### PR TITLE
Add support for Ruby 3.1 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,15 @@ jobs:
           gemfile: gemfiles/rails-6.0.gemfile
           experimental: false
         - mongodb: '4.4'
+          ruby: ruby-3.1
+          topology: replica_set
+          task: test
+          os: ubuntu-20.04
+          driver: current
+          rails: '6.0'
+          gemfile: gemfiles/rails-6.0.gemfile
+          experimental: false
+        - mongodb: '4.4'
           ruby: ruby-2.7
           topology: replica_set
           task: test
@@ -46,6 +55,15 @@ jobs:
           experimental: false
         - mongodb: '4.4'
           ruby: ruby-3.0
+          topology: replica_set
+          task: test
+          os: ubuntu-20.04
+          driver: current
+          rails: '6.1'
+          gemfile: gemfiles/rails-6.1.gemfile
+          experimental: false
+        - mongodb: '4.4'
+          ruby: ruby-3.1
           topology: replica_set
           task: test
           os: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           ruby: ruby-2.7
           topology: replica_set
           task: test
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           driver: current
           rails: '6.0'
           gemfile: gemfiles/rails-6.0.gemfile
@@ -30,7 +30,7 @@ jobs:
           ruby: ruby-3.0
           topology: replica_set
           task: test
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           driver: current
           rails: '6.0'
           gemfile: gemfiles/rails-6.0.gemfile
@@ -39,7 +39,7 @@ jobs:
           ruby: ruby-3.1
           topology: replica_set
           task: test
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           driver: current
           rails: '6.0'
           gemfile: gemfiles/rails-6.0.gemfile
@@ -48,7 +48,7 @@ jobs:
           ruby: ruby-2.7
           topology: replica_set
           task: test
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           driver: current
           rails: '6.1'
           gemfile: gemfiles/rails-6.1.gemfile
@@ -57,7 +57,7 @@ jobs:
           ruby: ruby-3.0
           topology: replica_set
           task: test
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           driver: current
           rails: '6.1'
           gemfile: gemfiles/rails-6.1.gemfile
@@ -66,7 +66,7 @@ jobs:
           ruby: ruby-3.1
           topology: replica_set
           task: test
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           driver: current
           rails: '6.1'
           gemfile: gemfiles/rails-6.1.gemfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           ruby: ruby-2.7
           topology: replica_set
           task: test
-          os: ubuntu-22.04
+          os: ubuntu-20.04
           driver: current
           rails: '6.0'
           gemfile: gemfiles/rails-6.0.gemfile
@@ -30,7 +30,7 @@ jobs:
           ruby: ruby-3.0
           topology: replica_set
           task: test
-          os: ubuntu-22.04
+          os: ubuntu-20.04
           driver: current
           rails: '6.0'
           gemfile: gemfiles/rails-6.0.gemfile
@@ -39,7 +39,7 @@ jobs:
           ruby: ruby-3.1
           topology: replica_set
           task: test
-          os: ubuntu-22.04
+          os: ubuntu-20.04
           driver: current
           rails: '6.0'
           gemfile: gemfiles/rails-6.0.gemfile
@@ -48,7 +48,7 @@ jobs:
           ruby: ruby-2.7
           topology: replica_set
           task: test
-          os: ubuntu-22.04
+          os: ubuntu-20.04
           driver: current
           rails: '6.1'
           gemfile: gemfiles/rails-6.1.gemfile
@@ -57,7 +57,7 @@ jobs:
           ruby: ruby-3.0
           topology: replica_set
           task: test
-          os: ubuntu-22.04
+          os: ubuntu-20.04
           driver: current
           rails: '6.1'
           gemfile: gemfiles/rails-6.1.gemfile
@@ -66,7 +66,7 @@ jobs:
           ruby: ruby-3.1
           topology: replica_set
           task: test
-          os: ubuntu-22.04
+          os: ubuntu-20.04
           driver: current
           rails: '6.1'
           gemfile: gemfiles/rails-6.1.gemfile

--- a/lib/mongoid/config/environment.rb
+++ b/lib/mongoid/config/environment.rb
@@ -54,7 +54,7 @@ module Mongoid
         if contents.empty?
           raise Mongoid::Errors::EmptyConfigFile.new(path)
         end
-        data = YAML.load(ERB.new(contents).result)
+        data = YAML.safe_load(ERB.new(contents).result, permitted_classes: [Symbol], aliases: true)
         unless data.is_a?(Hash)
           raise Mongoid::Errors::InvalidConfigFile.new(path)
         end

--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module Mongoid
-  VERSION = "7.0.14r3"
+  VERSION = "7.0.14r31"
 end


### PR DESCRIPTION
Adds support of new required syntax of psych gem. 

Part of [Ruby 3 upgrade](https://github.com/sensortower/orbital_command/issues/2931)